### PR TITLE
Update chart labels and template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,9 @@
+#### What’s this PR do?
+#### Where should the reviewer start?
+#### How should this be manually tested?
+#### Any background context you want to provide?
+#### What are the relevant tickets?
+#### Screenshots (if appropriate)
+#### Questions:
+# Implements/Fixes:
+* What issue does this close?

--- a/src/components/ComparisonChart/ComparisonChart.js
+++ b/src/components/ComparisonChart/ComparisonChart.js
@@ -19,8 +19,8 @@ class ComparisonChart extends Component{
   }
 
   getChartStuff = () => {
-    const { data, cityNames } = this.props;
-    
+    const { data, cityNames, chartIndex } = this.props;
+    const titles = ['Economy', 'Health & Safety', 'Culture', 'Infrastructure'];
     const chartData = {
         labels: data.cityOneData.map(datum => datum.name),
         datasets: this.myChartDataMap.map(({ chart, borderColor, borderWidth }, index) => ({
@@ -52,9 +52,12 @@ class ComparisonChart extends Component{
             }
           }
           ]
+        },
+        title: {
+          display: true,
+          text: titles[chartIndex]
         }
       };
-      
       return { chartData, chartOptions };
   }
 

--- a/src/containers/Comparison/Comparison.js
+++ b/src/containers/Comparison/Comparison.js
@@ -31,9 +31,10 @@ export const Comparison = (props) => {
         </div> :
         <div className="comparison-chart__container">
           {
-            chartList.map(chart =>
+            chartList.map((chart, i) =>
               <ComparisonChart
                 data={chart}
+                chartIndex={i}
                 key={Math.random(1)}
                 cityNames={cityNames}
               />)


### PR DESCRIPTION
#### What’s this PR do?

Includes a PR template in the root directory and updates rendering of individual charts with title object indicating category of chart. 

#### Where should the reviewer start?

Changes have been made in Comparison and ComparisonChart components. 

#### How should this be manually tested?

Comparing two cities should display four charts with titles that match the information displayed. 

#### Any background context you want to provide?
#### What are the relevant tickets?

See below.
 
#### Screenshots (if appropriate)
#### Questions:
# Implements/Fixes:
* What issue does this close?

#5 