### PR TITLE
Update styling and chart type

### DIFF
--- a/src/components/ComparisonChart/ComparisonChart.js
+++ b/src/components/ComparisonChart/ComparisonChart.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import './ComparisonChart.scss';
 import PropTypes from 'prop-types';
-import { Line } from 'react-chartjs-2';
+import { Bar } from 'react-chartjs-2';
 
 
 class ComparisonChart extends Component{
@@ -24,7 +24,7 @@ class ComparisonChart extends Component{
     const chartData = {
         labels: data.cityOneData.map(datum => datum.name),
         datasets: this.myChartDataMap.map(({ chart, borderColor, borderWidth }, index) => ({
-            type: 'line',
+            type: 'bar',
             label: cityNames[index],
             data: data[chart].map(datum => datum.score_out_of_10.toFixed(2)),
             fill: false,
@@ -65,7 +65,7 @@ class ComparisonChart extends Component{
     const chartStuff = this.getChartStuff();
     return(
         <div className='ComparisonChart'>
-          <Line
+          <Bar
             ref={(reference) => this.chartReference = reference}
             data={chartStuff.chartData}
             options={chartStuff.chartOptions}

--- a/src/containers/App/App.scss
+++ b/src/containers/App/App.scss
@@ -57,6 +57,7 @@ main {
   position: relative;
   height: 280px;
   width: 100%;
+  background-color: ghostwhite;
 
    & img {
     height: 200px;
@@ -66,7 +67,8 @@ main {
 
     &#circle {
       -webkit-clip-path: circle(75px at 50% 50%);
-      clip-path: circle(100px at 50% 50%);
+      clip-path: circle(80px at 50% 50%);
+      background-color: white;
     }
   }
 }

--- a/src/containers/CityForm/CityForm.js
+++ b/src/containers/CityForm/CityForm.js
@@ -93,7 +93,7 @@ export class CityForm extends Component{
 
   render() {
     const ordinal = this.props.ordinal;
-    const cityOrdinal = ordinal === 'one' ? 'First' : 'Second';
+    const cityOrdinal = ordinal === 0 ? 'First' : 'Second';
     const cities = this.state.cities;
     const cityNames = cities.length ? cities.map(city => <option key={city.name} value={city.name} />) : null;
     return(


### PR DESCRIPTION
#### What’s this PR do?

Updates ternary for first/second city to include integer instead of string, changes clip-path of cutout to show circle on default form view, changes type of chart from line to bar.

#### Where should the reviewer start?

Changes have been made in App.scss, CityForm, and ComparisonChart.

#### How should this be manually tested?

Selecting two cities should now show bar charts instead of line, placeholder svg should be surrounded by a circular cutout on a slightly darker background on default form, first and second city should be indicated accurately. 

#### Any background context you want to provide?
#### What are the relevant tickets?

#3 

#### Screenshots (if appropriate)
#### Questions:
# Implements/Fixes:
* What issue does this close?