### PR TITLE
Start history page

### DIFF
--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -30,9 +30,15 @@ export const App = (props) => {
           <h1>City<span>Life</span></h1>
         </div>
         <div className='nav-links'>
-          <NavLink to='/' className='nav'>Compare Cities</NavLink>
-          <NavLink to='/past-comparisons' className='nav'>History</NavLink>
-          <NavLink to='/world-map' className='nav'>Map</NavLink>
+          <div>
+            <NavLink to='/' className='nav'>Compare Cities</NavLink>
+          </div>
+          <div>
+            <NavLink to='/past-comparisons' className='nav'>History</NavLink>
+          </div>
+          <div>
+            <NavLink to='/world-map' className='nav'>Map</NavLink>
+          </div>
         </div>
       </header>
       <main>

--- a/src/containers/App/App.scss
+++ b/src/containers/App/App.scss
@@ -77,12 +77,12 @@ main {
   color: snow;
   text-decoration: none;
   font-size: 1em;
-  transition: font-size .2s ease-in-out;
+  transition: font-size .3s ease-in-out;
 
   &:hover {
     color: #6DECAF;
-    font-size: 1.15em;
-    transition: font-size .2s ease-in-out;
+    font-size: 1.2em;
+    transition: font-size .3s ease-in-out;
   }
 
   &:focus {

--- a/src/containers/App/App.scss
+++ b/src/containers/App/App.scss
@@ -56,7 +56,7 @@ main {
 .placeholder {
   position: relative;
   height: 280px;
-  width: 100%;
+  width: 90%;
   background-color: ghostwhite;
 
    & img {
@@ -79,6 +79,11 @@ main {
 
   &:hover {
     color: #6DECAF;
+  }
+
+  &:focus {
+    color: #6DECAF;
+    outline: none;
   }
 }
 

--- a/src/containers/App/App.scss
+++ b/src/containers/App/App.scss
@@ -76,14 +76,19 @@ main {
 .nav {
   color: snow;
   text-decoration: none;
+  font-size: 1em;
+  transition: font-size .2s ease-in-out;
 
   &:hover {
     color: #6DECAF;
+    font-size: 1.15em;
+    transition: font-size .2s ease-in-out;
   }
 
   &:focus {
     color: #6DECAF;
     outline: none;
+
   }
 }
 

--- a/src/containers/App/__snapshots__/App.test.js.snap
+++ b/src/containers/App/__snapshots__/App.test.js.snap
@@ -20,24 +20,30 @@ exports[`App should match the snapshot with data passed in correctly 1`] = `
     <div
       className="nav-links"
     >
-      <NavLink
-        className="nav"
-        to="/"
-      >
-        Compare Cities
-      </NavLink>
-      <NavLink
-        className="nav"
-        to="/past-comparisons"
-      >
-        History
-      </NavLink>
-      <NavLink
-        className="nav"
-        to="/world-map"
-      >
-        Map
-      </NavLink>
+      <div>
+        <NavLink
+          className="nav"
+          to="/"
+        >
+          Compare Cities
+        </NavLink>
+      </div>
+      <div>
+        <NavLink
+          className="nav"
+          to="/past-comparisons"
+        >
+          History
+        </NavLink>
+      </div>
+      <div>
+        <NavLink
+          className="nav"
+          to="/world-map"
+        >
+          Map
+        </NavLink>
+      </div>
     </div>
   </header>
   <main>

--- a/src/containers/City/City.scss
+++ b/src/containers/City/City.scss
@@ -2,7 +2,7 @@
   position: relative;
   background: ghostwhite;
   height: 280px;
-  width: 100%;
+  width: 90%;
 
   & div{
     position: relative;

--- a/src/containers/CityForm/CityForm.js
+++ b/src/containers/CityForm/CityForm.js
@@ -118,7 +118,10 @@ export class CityForm extends Component{
           <datalist id='city-selection'>
             {cityNames}
           </datalist>
-          <button type='submit' disabled={!this.state.city} onClick={this.handleSubmitCity}>
+          <button 
+            type='submit' 
+            disabled={!this.state.city} 
+            onClick={this.handleSubmitCity}>
             Select City
           </button>
         </form>

--- a/src/containers/CityForm/CityForm.scss
+++ b/src/containers/CityForm/CityForm.scss
@@ -22,9 +22,7 @@
   }
 
   & label {
-    position: relative;
-    right: 33%;
-    margin: 0px 0px 0px 10px;
+    display: none;
   }
 
   & button {

--- a/src/containers/CityForm/CityForm.scss
+++ b/src/containers/CityForm/CityForm.scss
@@ -31,6 +31,8 @@
       width: 90%;
       border-radius: 10px;
       margin: 10px 0px 10px 0px;
+      background-color: #FFF;
+      transition: all 0.2s ease-in-out;
 
     &:hover {
       color: ghostwhite;

--- a/src/containers/CityForm/CityForm.scss
+++ b/src/containers/CityForm/CityForm.scss
@@ -4,7 +4,7 @@
   justify-content: center;
   align-items: center;
   height: 150px;
-  width: 100%;
+  width: 90%;
   position: relative;
   background-color: ghostwhite;
 

--- a/src/containers/Comparison/Comparison.scss
+++ b/src/containers/Comparison/Comparison.scss
@@ -1,7 +1,6 @@
 .comparison-chart__container {
   display: grid;
   grid-template: 1fr 1fr/1fr 1fr;
-  background-color: ghostwhite;
   min-height: 112.3vh;
   width: 100%;
 }

--- a/src/containers/Comparison/Comparison.scss
+++ b/src/containers/Comparison/Comparison.scss
@@ -3,6 +3,7 @@
   grid-template: 1fr 1fr/1fr 1fr;
   min-height: 112.3vh;
   width: 100%;
+  margin: 0px 0px 0px 25px;
 }
 
 .instructions {


### PR DESCRIPTION
#### What’s this PR do?

Flattens out styling of main page, removing unnecessary background colors and adding in css rules to allow for ease-out transition to be visible on navlinks and buttons, increases font-size of navlinks on focus and hover. Decreases size of cityform, placeholder, and city.

#### Where should the reviewer start?

Changes have been made in App, City, CityForm, and Comparison.

#### How should this be manually tested?

Hovering over navlinks should display font-size change, buttons in form should have ease-out transition. 

#### Any background context you want to provide?
#### What are the relevant tickets?

#3 

#### Screenshots (if appropriate)
#### Questions:
# Implements/Fixes:
* What issue does this close?